### PR TITLE
Revert "Restrict groups in client"

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,9 +17,6 @@ jobs:
         run: bin/build.sh
         env:
           HYPOTHESIS_EMBED_URL: https://hypothes.is/embed.js
-          HYPOTHESIS_API_URL: https://hypothes.is/api/
-          HYPOTHESIS_AUTHORITY: hypothes.is
-          HYPOTHESIS_GROUPS: '"Pi3Pmdmm", "6279Y8xA"'
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 mkdir -p build
-envsubst '${HYPOTHESIS_EMBED_URL},${HYPOTHESIS_API_URL},${HYPOTHESIS_AUTHORITY},${HYPOTHESIS_GROUPS}' < src/index.html > build/index.html
+envsubst '${HYPOTHESIS_EMBED_URL}' < src/index.html > build/index.html
 cp -r src/assets build

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -2,10 +2,7 @@
 set -euo pipefail
 
 HYPOTHESIS_EMBED_URL=http://localhost:5000/embed.js
-HYPOTHESIS_API_URL=http://localhost:5000/api/
-HYPOTHESIS_AUTHORITY=localhost
-HYPOTHESIS_GROUPS='"Pi3Pmdmm", "6279Y8xA"'
-export HYPOTHESIS_EMBED_URL HYPOTHESIS_API_URL HYPOTHESIS_AUTHORITY HYPOTHESIS_GROUPS
+export HYPOTHESIS_EMBED_URL
 
 bin/build.sh
 python3 -m http.server -b 127.0.0.1 47291 -d build

--- a/src/index.html
+++ b/src/index.html
@@ -4,12 +4,7 @@
   <script type="application/json" class="js-hypothesis-config">
     {
       "enableExperimentalNewNoteButton": true,
-      "externalContainerSelector": "#hypothesis",
-      "services": [{
-        "apiUrl": "${HYPOTHESIS_API_URL}",
-        "authority": "${HYPOTHESIS_AUTHORITY}",
-        "groups": [${HYPOTHESIS_GROUPS}]
-      }]
+      "externalContainerSelector": "#hypothesis"
     }
   </script>
   <script async src="${HYPOTHESIS_EMBED_URL}"></script>


### PR DESCRIPTION
Reverts hypothesis/biotome#7. This seems to cause various breakage (e.g. the log in, log out and sign up buttons in the client are broken, also an "unable to fetch groups" error is shown when first loading the client)