### PR TITLE
Enable comments mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ To embed Hypothesis into a site like in the demo linked above you just need to a
 ```html
 <script type="application/json" class="js-hypothesis-config">
   {
+    "commentsMode": true,
+    "showHighlights": false,
     "enableExperimentalNewNoteButton": true,
     "externalContainerSelector": "#hypothesis"
   }

--- a/src/index.html
+++ b/src/index.html
@@ -3,6 +3,8 @@
   <head>
   <script type="application/json" class="js-hypothesis-config">
     {
+      "commentsMode": true,
+      "showHighlights": false,
       "enableExperimentalNewNoteButton": true,
       "externalContainerSelector": "#hypothesis"
     }
@@ -1961,7 +1963,7 @@
           </div>
         </div>
         <div class="csh_panelc-body" style="height: 100%;">
-          <div class="tabcontent" id="sect_comments" style="height:100%;">
+          <div class="tabcontent" id="sect_comments" style="height:100%; display: flex; flex-direction: column">
             <div class="tab-header" id="sect_comments_header">
               <p class="tab-title"><i class="icon-comment-alt"></i> Comments</p>
               <p class="tab-description">
@@ -1983,8 +1985,7 @@
                 copy link)</a
               ><span class="comments-tab-share-message">Copied!</span>
             </div>
-            <div id="hypothesis" style="height:100%;">
-            </div>
+            <div id="hypothesis" style="height:100%;"></div>
           </div>
           <div class="tabcontent nocontent" id="sect_trip">
             <div class="tab-header">


### PR DESCRIPTION
Part of https://github.com/hypothesis/client/issues/7065

Enable comments mode with the settings introduced in https://github.com/hypothesis/client/pull/7396

Additionally, fix an issue with styling that was making the sidebar to overflow its container vertically.

<img width="1579" height="961" alt="image" src="https://github.com/user-attachments/assets/fa718b6e-5931-42ff-b47f-363633d06c3e" />
