### PR TITLE
Enable groups allowlist setting

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ jobs:
         run: bin/build.sh
         env:
           HYPOTHESIS_EMBED_URL: https://hypothes.is/embed.js
+          HYPOTHESIS_GROUPS_ALLOWLIST: 'Pi3Pmdmm,PyEqGn2e'
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 mkdir -p build
-envsubst '${HYPOTHESIS_EMBED_URL}' < src/index.html > build/index.html
+envsubst '${HYPOTHESIS_EMBED_URL} ${HYPOTHESIS_GROUPS_ALLOWLIST}' < src/index.html > build/index.html
 cp -r src/assets build

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-HYPOTHESIS_EMBED_URL=http://localhost:5000/embed.js
-export HYPOTHESIS_EMBED_URL
+export HYPOTHESIS_EMBED_URL=http://localhost:5000/embed.js
+export HYPOTHESIS_GROUPS_ALLOWLIST="__world__"
 
 bin/build.sh
 python3 -m http.server -b 127.0.0.1 47291 -d build

--- a/src/index.html
+++ b/src/index.html
@@ -1,13 +1,16 @@
 <!doctype html>
 <html lang="en">
   <head>
-  <script type="application/json" class="js-hypothesis-config">
-    {
-      "commentsMode": true,
-      "showHighlights": false,
-      "enableExperimentalNewNoteButton": true,
-      "externalContainerSelector": "#hypothesis"
-    }
+  <script>
+    window.hypothesisConfig = function () {
+      return {
+        commentsMode: true,
+        showHighlights: false,
+        enableExperimentalNewNoteButton: true,
+        externalContainerSelector: '#hypothesis',
+        groupsAllowlist: '${HYPOTHESIS_GROUPS_ALLOWLIST}'.split(',')
+      };
+    };
   </script>
   <script async src="${HYPOTHESIS_EMBED_URL}"></script>
   <style>


### PR DESCRIPTION
Part of https://github.com/hypothesis/client/issues/7065

Enable `groupsAllowlist` in the biotome example site, suing bioRxiv and mediRxiv groups in production, and `public` group in dev.