### PR TITLE
Open comments sidebar when deeplinking to an individual annotation

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -38,6 +38,13 @@
       function closeSidebar() {
         document.getElementById('csh_sidebar').classList.remove('activec');
       }
+
+      document.addEventListener('DOMContentLoaded', () => {
+        const { hash } = window.location;
+        if (hash.includes('annotations:')) {
+          openSidebar('comments');
+        }
+      });
     </script>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <link rel="shortcut icon" href="assets/favicon.ico" type="image/vnd.microsoft.icon" />


### PR DESCRIPTION
Depends on https://github.com/hypothesis/client/pull/7442
Part of https://github.com/orgs/hypothesis/projects/157/views/1?pane=issue&itemId=111060884

Update site so that the comments sidebar is opened when deeplinking to an annotation (comment), as an example for sites that render the sidebar in custom containers and want to do the same.